### PR TITLE
gstreamer: cleaner implementation

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mesonbuild meson 0.62.2
+github.setup        mesonbuild meson 0.63.3
 github.tarball_from releases
 revision            0
 
@@ -12,7 +12,6 @@ github.tarball_from releases
 license             Apache-2
 categories          devel python
 maintainers         {@gcenx}
-platforms           darwin
 supported_archs     noarch
 installs_libs       no
 homepage            https://mesonbuild.com
@@ -24,9 +23,9 @@ long_description    Meson is a build system designed to optimize programmer prod
                     Valgrind, CCache and the like. It is both extremely fast, and, even more importantly, \
                     as user friendly as possible.
 
-checksums           rmd160  286f63204b0121193edac960c539bf4a4a2f2d1c \
-                    sha256  a7669e4c4110b06b743d57cc5d6432591a6677ef2402139fe4f3d42ac13380b0 \
-                    size    2038542
+checksums           rmd160  f406db9edc320ef4bc76aa8f6d5a80b5e1e8927a \
+                    sha256  519c0932e1a8b208741f0fdce90aa5c0b528dd297cf337009bf63539846ac056 \
+                    size    2067612
 
 python.default_version  310
 python.link_binaries    no
@@ -69,7 +68,7 @@ platform darwin 8 {
 
     github.setup        mesonbuild meson 0.58.2
     github.tarball_from releases
-    revision            1
+    revision            0
     checksums           rmd160  252d6261d3b8ecad345b1f966f8cfc60b52da6e1 \
                         sha256  7634ec32955d3f897d623b88e9d2988451035f43d73c17a29caf767387baedb7 \
                         size    1899464

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -55,56 +55,36 @@ long_description    FFmpeg is a complete solution to record, convert and \
                     libavformat is a library containing parsers and \
                     generators for all common audio/video formats.
 
-platforms           darwin
 homepage            https://ffmpeg.org/
 master_sites        ${homepage}releases/
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  ebb1f042b2ba4f13be86339d30522cd73eb6da3e \
-                    sha256  eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02 \
-                    size    9557516
+checksums \
+    rmd160  ebb1f042b2ba4f13be86339d30522cd73eb6da3e \
+    sha256  eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02 \
+    size    9557516
 
-depends_build       port:pkgconfig \
-                    port:gmake \
-                    port:texinfo
+depends_build \
+    port:nasm
 
-depends_lib         port:aom \
-                    port:lame \
-                    port:dav1d \
-                    port:libiconv \
-                    port:libvorbis \
-                    port:libopus \
-                    port:libogg \
-                    port:libtheora \
-                    port:libmodplug \
-                    port:libvpx \
-                    port:fontconfig \
-                    port:freetype \
-                    port:fribidi \
-                    path:lib/libspeex.dylib:speex \
-                    port:soxr \
-                    port:bzip2 \
-                    port:xz \
-                    port:XviD \
-                    port:x264 \
-                    port:x265 \
-                    port:zlib
-
-patchfiles          patch-libavcodec-audiotoolboxenc.c.diff
+patchfiles \
+    patch-libavcodec-audiotoolboxenc.c.diff
 
 # Fix an upstream bug that overrides the max_b_frames setting
 # https://trac.ffmpeg.org/ticket/9231
 # This bug is fixed upstream in commit 55d9d6767967794edcdd6e1bbd8840fc6f4e9315
 # and should therefore be available in the next release version.
-patchfiles-append   patch-libavcodec-videotoolboxenc.c.diff
+patchfiles-append \
+    patch-libavcodec-videotoolboxenc.c.diff
 
 # Patch for upstream bug related to non-B-frame encoding
 # https://trac.ffmpeg.org/ticket/9439
 # Fixed via upstream commit: b786bc7433dfe082441a57c1ba9ae9ea47904b78
 # Will be available in the next release version
-patchfiles-append   patch-issue-9439-non-b-frame-encoding.diff
+patchfiles-append \
+    patch-issue-9439-non-b-frame-encoding.diff
 
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard
@@ -121,128 +101,36 @@ compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}
 
 configure.cflags-append -DHAVE_LRINTF ${configure.cppflags}
-configure.args      --mandir=${prefix}/share/man \
-                    --enable-gpl \
-                    --enable-shared \
-                    --enable-swscale \
-                    --enable-postproc \
-                    --enable-avfilter \
-                    --enable-avresample \
-                    --enable-pthreads \
-                    --disable-indev=jack \
-                    --disable-outdev=xv \
-                    --disable-alsa \
-                    --disable-gcrypt \
-                    --disable-gmp \
-                    --disable-gnutls \
-                    --disable-libass \
-                    --disable-libbluray \
-                    --enable-libdav1d \
-                    --enable-libfontconfig \
-                    --enable-libfreetype \
-                    --enable-libfribidi \
-                    --enable-libmodplug \
-                    --enable-libmp3lame \
-                    --enable-libopus \
-                    --enable-libsoxr \
-                    --enable-libspeex \
-                    --enable-libtheora \
-                    --enable-libvorbis \
-                    --enable-libvpx \
-                    --enable-libx264 \
-                    --enable-libx265 \
-                    --disable-libxcb \
-                    --disable-libxcb-shm \
-                    --disable-libxcb-xfixes \
-                    --disable-libxcb-shape \
-                    --enable-libxvid \
-                    --enable-lzma \
-                    --disable-openssl \
-                    --disable-sndio \
-                    --disable-sdl2 \
-                    --disable-securetransport \
-                    --disable-xlib \
-                    --enable-zlib \
-                    --enable-audiotoolbox \
-                    --enable-videotoolbox \
-                    --cc=${configure.cc}
+configure.args \
+    --enable-shared \
+    --disable-static \
+    --disable-everything \
+    --disable-programs \
+    --disable-doc \
+    --enable-decoder=mpeg4 \
+    --enable-decoder=msmpeg4v1 \
+    --enable-decoder=msmpeg4v2 \
+    --enable-decoder=msmpeg4v3 \
+    --enable-decoder=vc1 \
+    --enable-decoder=wmav1 \
+    --enable-decoder=wmav2 \
+    --enable-decoder=wmapro \
+    --enable-decoder=wmalossless \
+    --enable-decoder=xma1 \
+    --enable-decoder=xma2 \
+    --enable-decoder=wmv3image \
+    --enable-decoder=wmv3 \
+    --enable-decoder=wmv2 \
+    --enable-decoder=wmv1 \
+    --enable-decoder=h264 \
+    --enable-decoder=aac \
+    --enable-demuxer=xwma \
+    --enable-audiotoolbox \
+    --enable-videotoolbox \
+    --cc=${configure.cc}
 
-build.cmd           ${prefix}/bin/gmake
 build.env-append    V=1
-
-test.run            yes
-
 destroot.env-append V=1
-
-#
-# configure isn't autoconf and they do use a dep cache
-#
-
-post-destroot {
-    file mkdir ${destroot}${prefix}/share/doc/ffmpeg
-    file copy ${worksrcpath}/doc/APIchanges ${destroot}${prefix}/share/doc/ffmpeg
-    foreach f [glob ${worksrcpath}/doc/*.txt] {
-        file copy $f ${destroot}${prefix}/share/doc/ffmpeg
-    }
-}
-
-configure.universal_args-delete --disable-dependency-tracking
-
-if {${universal_possible} && [variant_isset universal]} {
-    foreach arch ${configure.universal_archs} {
-        set merger_host($arch) ""
-        lappend merger_configure_args($arch) --arch=${arch}
-        lappend merger_configure_env($arch)  ASFLAGS='-arch ${arch}'
-    }
-    if {[string match "*86*" ${configure.universal_archs}]} {
-        depends_build-append port:nasm
-    }
-    lappend merger_configure_args(i386) --enable-x86asm
-    lappend merger_configure_args(x86_64) --enable-x86asm
-} else {
-    configure.args-append --arch=${configure.build_arch}
-    configure.env-append  ASFLAGS=[get_canonical_archflags]
-    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
-        depends_build-append port:nasm
-        configure.args-append --enable-x86asm
-    }
-}
-
-# the build server uses the default variants, and we want distributable binaries
-# nonfree code is disabled by default but can be enabled using the +nonfree variant
-
-variant nonfree description {enable nonfree code, libraries and binaries will not be redistributable} {
-    configure.args-append   --enable-nonfree \
-                            --enable-libfdk-aac
-    depends_lib-append      port:libfdk-aac
-    license                 Restrictive
-}
-
-if {[variant_isset nonfree]} {
-notes "
-This build of ${name} includes nonfree code as follows:
-  libfdk-aac
-The following libraries and binaries may not be redistributed:
-  ffmpeg
-  libavcodec
-  libavdevice
-  libavfilter
-  libavformat
-  libavutil
-To remove this restriction remove the variant +nonfree
-"
-} else {
-notes "
-This build of ${name} includes GPLed code and is therefore licensed under GPL v2 or later.
-The following modules are GPLed:
-  postproc
-  libx264
-  libx265
-  libxvid
-To include all nonfree, GPLed and LGPL code use variant +nonfree.
-To remove nonfree and GPLed code leaving only LGPL code remove the +gpl2 variant.
-"
-}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/multimedia/gstreamer/Portfile
+++ b/multimedia/gstreamer/Portfile
@@ -161,8 +161,11 @@ subport gst-plugins-good {
         ${worksrcpath}/subprojects/gst-plugins-good
 
     depends_lib-append \
+        port:flac \
         port:gst-plugins-base \
-        port:mpg123
+        port:lame \
+        port:mpg123 \
+        port:libvpx
 
     # Feature options for plugins without external deps
     configure.args-append \
@@ -177,18 +180,18 @@ subport gst-plugins-good {
         -Ddirectsound=enabled \
         -Ddv=disabled \
         -Ddv1394=disabled \
-        -Dflac=disabled \
+        -Dflac=enabled \
         -Dgdk-pixbuf=disabled \
         -Dgtk3=disabled \
         -Djack=disabled \
         -Djpeg=disabled \
-        -Dlame=disabled \
+        -Dlame=enabled \
         -Dlibcaca=disabled \
         -Dmpg123=enabled \
         -Doss=disabled \
         -Doss4=disabled \
-        -Dosxaudio=disabled \
-        -Dosxvideo=disabled \
+        -Dosxaudio=enabled \
+        -Dosxvideo=enabled \
         -Dpng=disabled \
         -Dpulse=disabled \
         -Dqt5=disabled \
@@ -197,7 +200,7 @@ subport gst-plugins-good {
         -Dspeex=disabled \
         -Dtaglib=disabled \
         -Dtwolame=disabled \
-        -Dvpx=disabled \
+        -Dvpx=enabled \
         -Dwaveform=disabled \
         -Dwavpack=disabled
 

--- a/multimedia/gstreamer/Portfile
+++ b/multimedia/gstreamer/Portfile
@@ -112,6 +112,8 @@ subport gst-plugins-base {
     depends_lib-append \
         port:gstreamer \
         port:libogg \
+        port:libopus \
+        port:libvorbis \
         port:zlib
 
     # Feature option for opengl plugin and integration library
@@ -132,11 +134,11 @@ subport gst-plugins-base {
         -Dcdparanoia=disabled \
         -Dlibvisual=disabled \
         -Dogg=enabled \
-        -Dopus=disabled \
+        -Dopus=enabled \
         -Dpango=disabled \
         -Dtheora=disabled \
         -Dtremor=disabled \
-        -Dvorbis=disabled \
+        -Dvorbis=enabled \
         -Dx11=disabled \
         -Dxshm=disabled \
         -Dxvideo=disabled

--- a/multimedia/gstreamer/Portfile
+++ b/multimedia/gstreamer/Portfile
@@ -1,0 +1,471 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           meson 1.0
+
+# https://bugzilla.gnome.org/show_bug.cgi?id=636134
+PortGroup           muniversal 1.0
+
+# please only commit stable updates (even numbered releases)
+gitlab.setup        gstreamer gstreamer 1.20.3
+
+conflicts           gstreamer1 \
+                    gstreamer1-gst-plugins-base \
+                    gstreamer1-gst-plugins-good \
+                    gstreamer1-gst-plugins-bad \
+                    gstreamer1-gst-plugins-ugly \
+                    gstreamer1-gst-libav
+
+maintainers         {@gcenx}
+categories          multimedia
+license             LGPL-2+
+
+checksums \
+    rmd160  c23d951774a05622d7795b1669e2649dcb987399 \
+    sha256  2b74ca3aad12e87fcfe85e3f21f16353e3e7eebeaa89fe9bb5e2e9f58a3094ba \
+    size    29344033
+
+depends_build-append \
+    port:bison \
+    port:gettext \
+    port:pkgconfig
+
+depends_lib-append \
+    port:gettext-runtime \
+    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+    port:orc
+
+# https://github.com/mesonbuild/meson/issues/1889
+compiler.cxx_standard \
+    2014
+
+# Common feature options
+configure.args-append \
+    -Dexamples=disabled \
+    -Dtests=disabled \
+    -Dbenchmarks=disabled \
+    -Dtools=disabled \
+    -Dintrospection=disabled \
+    -Dnls=disabled \
+    -Dorc=enabled \
+    -Dgobject-cast-checks=disabled \
+    -Dglib-asserts=disabled \
+    -Dglib-checks=disabled \
+    -Dextra-checks=disabled
+
+
+subport gstreamer {
+    description \
+        GStreamer is a streaming media framework
+    long_description \
+        GStreamer is a streaming media framework that allows the construction of \
+        graphs of elements which operate on media data. \
+        Applications using this library can do anything from real-time sound processing \
+        over playing video to capturing audio, video, and even other types of media \
+        data. \
+        Its architecture allows for adding new data types or processing capabilities \
+        simply by installing new plug-ins. \
+        GStreamer is the core module, containing libraries, headers, the basic object \
+        hierarchy, and a set of media-agnostic core elements.
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gstreamer
+
+    configure.args-append \
+        -Dgst_debug=true \
+        -Dgst_parse=false \
+        -Dregistry=true \
+        -Dtracer_hooks=true \
+        -Dptp-helper-permissions=none
+
+    depends_lib-delete \
+        port:orc
+
+    # Feature options
+    configure.args-append \
+        -Dcheck=disabled \
+        -Dlibunwind=disabled \
+        -Dlibdw=disabled \
+        -Ddbghelp=disabled \
+        -Dbash-completion=disabled \
+        -Dcoretracers=disabled
+
+    configure.args-delete \
+        -Dorc=enabled
+}
+
+
+subport gst-plugins-base {
+    description \
+        GStreamer Base Plug-ins a basic collection of elements
+    long_description \
+        GStreamer Base Plug-ins is a well-groomed and well-maintained collection of \
+        GStreamer plug-ins and elements, spanning the range of possible types of \
+        elements one would want to write for GStreamer.  It also contains helper \
+        libraries and base classes useful for writing elements. \
+        A wide range of video and audio decoders, encoders, and filters are included.
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gst-plugins-base
+
+    depends_lib-append \
+        port:gstreamer \
+        port:libogg \
+        port:zlib
+
+    # Feature option for opengl plugin and integration library
+    configure.args-append \
+        -Dgl=disabled \
+        -Dgl-graphene=disabled \
+        -Dgl-jpeg=disabled \
+        -Dgl-png=disabled
+
+    # Feature options for plugins with no external deps
+    configure.args-append \
+        -Dtcp=disabled \
+        -Dvideotestsrc=disabled
+
+    # Feature options for plugins with external deps
+    configure.args-append \
+        -Dalsa=disabled \
+        -Dcdparanoia=disabled \
+        -Dlibvisual=disabled \
+        -Dogg=enabled \
+        -Dopus=disabled \
+        -Dpango=disabled \
+        -Dtheora=disabled \
+        -Dtremor=disabled \
+        -Dvorbis=disabled \
+        -Dx11=disabled \
+        -Dxshm=disabled \
+        -Dxvideo=disabled
+
+    configure.args-delete \
+        -Dbenchmarks=disabled \
+        -Dextra-checks=disabled
+}
+
+
+subport gst-plugins-good {
+    description \
+        GStreamer Good Plug-ins a set of good-quality plug-ins under our preferred license, LGPL
+    long_description \
+        GStreamer Good Plug-ins is a set of plug-ins that we consider to have good \
+        quality code and correct functionality, under our preferred license (LGPL for \
+        the plug-in code, LGPL or LGPL-compatible for the supporting library).
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gst-plugins-good
+
+    depends_lib-append \
+        port:gst-plugins-base \
+        port:mpg123
+
+    # Feature options for plugins without external deps
+    configure.args-append \
+        -Ddebugutils=disabled \
+        -Ddtmf=disabled
+
+    # Feature options for plugins with external deps
+    configure.args-append \
+        -Daalib=disabled \
+        -Dbz2=disabled \
+        -Dcairo=disabled \
+        -Ddirectsound=enabled \
+        -Ddv=disabled \
+        -Ddv1394=disabled \
+        -Dflac=disabled \
+        -Dgdk-pixbuf=disabled \
+        -Dgtk3=disabled \
+        -Djack=disabled \
+        -Djpeg=disabled \
+        -Dlame=disabled \
+        -Dlibcaca=disabled \
+        -Dmpg123=enabled \
+        -Doss=disabled \
+        -Doss4=disabled \
+        -Dosxaudio=disabled \
+        -Dosxvideo=disabled \
+        -Dpng=disabled \
+        -Dpulse=disabled \
+        -Dqt5=disabled \
+        -Dshout2=disabled \
+        -Dsoup=disabled \
+        -Dspeex=disabled \
+        -Dtaglib=disabled \
+        -Dtwolame=disabled \
+        -Dvpx=disabled \
+        -Dwaveform=disabled \
+        -Dwavpack=disabled
+
+    # ximagesrc plugin options
+    configure.args-append \
+        -Dximagesrc=disabled
+
+    # v4l2 plugin options
+    configure.args-append \
+        -Dv4l2=disabled
+
+    configure.args-delete \
+        -Dbenchmarks=disabled \
+        -Dintrospection=disabled \
+        -Dextra-checks=disabled \
+        -Dtools=disabled
+}
+
+
+subport gst-plugins-ugly {
+    description \
+        GStreamer Ugly Plug-ins a set of good-quality plug-ins with license or patent problems.
+    long_description \
+        GStreamer Ugly Plug-ins is a set of plug-ins that have good quality and correct \
+        functionality, but distributing them might pose problems. The license on either \
+        the plug-ins or the supporting libraries might not be how we'd like. The code \
+        might be widely known to present patent problems.
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gst-plugins-ugly
+
+    depends_lib-append \
+        port:gst-plugins-base \
+        port:libmpeg2 \
+        port:x264
+
+    # Feature options for plugins without external deps
+    configure.args-append \
+        -Ddvdsub=disabled
+
+    # Feature options for plugins that need external deps
+    configure.args-append \
+        -Da52dec=disabled \
+        -Damrnb=disabled \
+        -Damrwbdec=disabled \
+        -Dcdio=disabled \
+        -Ddvdread=disabled \
+        -Dmpeg2dec=enabled \
+        -Dsidplay=disabled \
+        -Dx264=enabled
+
+    # License-related feature options
+    configure.args-append \
+        -Dgpl=enabled
+
+    configure.args-delete \
+        -Dexamples=disabled \
+        -Dbenchmarks=disabled \
+        -Dtools=disabled \
+        -Dintrospection=disabled \
+        -Dextra-checks=disabled
+}
+
+
+subport gst-plugins-bad {
+    description \
+        GStreamer Bad Plug-ins a set of lower-quality plug-ins that need some love.
+    long_description \
+        GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared to \
+        the rest. They might be close to being good quality, but they're missing \
+        something - be it a good code review, some documentation, a set of tests, a \
+        real live maintainer, or some actual wide use.
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gst-plugins-bad
+
+    depends_lib-append \
+        port:faac \
+        port:faad2 \
+        port:gst-plugins-base \
+        path:include/turbojpeg.h:libjpeg-turbo \
+        port:libfdk-aac \
+        port:libusrsctp \
+        port:libopus \
+        port:libsrtp \
+        port:rtmpdump \
+        port:x265
+
+    # Enable GstPlay tests that need network access
+    configure.args-append \
+        -Dgst_play_tests=false
+
+    # Feature options for libraries that need external deps
+    configure.args-append \
+        -Dopencv=disabled
+
+    # Feature options for optional deps in plugins
+    configure.args-append \
+        -Dwayland=disabled \
+        -Dx11=disabled
+
+    # Feature options for plugins that need external deps
+    configure.args-append \
+        -Daes=disabled \
+        -Daom=disabled \
+        -Davtp=disabled \
+        -Dandroidmedia=disabled \
+        -Dapplemedia=disabled \
+        -Dasio=disabled \
+        -Dasio-sdk-path= \
+        -Dassrender=disabled \
+        -Dbluez=disabled \
+        -Dbs2b=disabled \
+        -Dbz2=disabled \
+        -Dchromaprint=disabled \
+        -Dclosedcaption=disabled \
+        -Dcolormanagement=disabled \
+        -Dcurl=disabled \
+        -Dcurl-ssh2=disabled \
+        -Dd3dvideosink=disabled \
+        -Dd3d11=disabled \
+        -Ddash=disabled \
+        -Ddc1394=disabled \
+        -Ddecklink=disabled \
+        -Ddirectfb=disabled \
+        -Ddirectsound=disabled \
+        -Ddtls=disabled \
+        -Ddts=disabled \
+        -Ddvb=disabled \
+        -Dfaac=enabled \
+        -Dfaad=enabled \
+        -Dfbdev=disabled \
+        -Dfdkaac=enabled \
+        -Dflite=disabled \
+        -Dfluidsynth=disabled \
+        -Dgl=disabled \
+        -Dgme=disabled \
+        -Dgs=disabled \
+        -Dgsm=disabled \
+        -Dipcpipeline=disabled \
+        -Dipcpipeline=disabled \
+        -Diqa=disabled \
+        -Dkate=disabled \
+        -Dkms=disabled \
+        -Dladspa=disabled \
+        -Dldac=disabled \
+        -Dlibde265=disabled \
+        -Dopenaptx=disabled \
+        -Dlv2=disabled \
+        -Dmediafoundation=disabled \
+        -Dmicrodns=disabled \
+        -Dmodplug=disabled \
+        -Dmpeg2enc=disabled \
+        -Dmplex=disabled \
+        -Dmsdk=disabled \
+        -Dmusepack=disabled \
+        -Dneon=disabled \
+        -Dnvcodec=disabled \
+        -Donnx=disabled \
+        -Dopenal=disabled \
+        -Dopenexr=disabled \
+        -Dopenh264=disabled \
+        -Dopenjpeg=disabled \
+        -Dopenmpt=disabled \
+        -Dopenni2=disabled \
+        -Dopensles=disabled \
+        -Dopus=disabled \
+        -Dqroverlay=disabled \
+        -Dresindvd=disabled \
+        -Drsvg=disabled \
+        -Drtmp=disabled \
+        -Dsbc=disabled \
+        -Dsctp=disabled \
+        -Dshm=disabled \
+        -Dsmoothstreaming=disabled \
+        -Dsndfile=disabled \
+        -Dsoundtouch=disabled \
+        -Dspandsp=disabled \
+        -Dsrt=disabled \
+        -Dsrtp=disabled \
+        -Dsvthevcenc=disabled \
+        -Dteletext=disabled \
+        -Dtinyalsa=disabled \
+        -Dtranscode=disabled \
+        -Dttml=disabled \
+        -Duvch264=disabled \
+        -Dva=disabled \
+        -Dvoaacenc=disabled \
+        -Dvoamrwbenc=disabled \
+        -Dvulkan=disabled \
+        -Dwasapi=disabled \
+        -Dwasapi2=disabled \
+        -Dwebp=disabled \
+        -Dwebrtc=disabled \
+        -Dwebrtcdsp=disabled \
+        -Dwildmidi=disabled \
+        -Dwinks=disabled \
+        -Dwinscreencap=disabled \
+        -Dx265=enabled \
+        -Dzbar=disabled \
+        -Dzxing=disabled \
+        -Dwpe=disabled \
+        -Dmagicleap=disabled \
+        -Dv4l2codecs=disabled \
+        -Disac=disabled
+
+    # We put this into a pre-configure block so it can be evaluated _after_ platform selection.
+    pre-configure {
+        # Disable applemedia for macOS High Sierra and below
+        if {[vercmp $macosx_deployment_target 10.14] < 0 } {
+            configure.args-delete -Dapplemedia=enabled
+            configure.args-append -Dapplemedia=disabled
+        }
+    }
+
+    # HLS plugin options
+    configure.args-append \
+        -Dhls=auto \
+        -Dhls-crypto=auto
+
+    # SCTP plugin options
+    configure.args-append \
+        -Dsctp-internal-usrsctp=auto
+
+    # MSDK plugin options
+    configure.args-append \
+        -Dmfx_api=auto
+
+    # License-related feature options
+    configure.args-append \
+        -Dgpl=enabled
+
+    configure.args-delete \
+        -Dbenchmarks=disabled \
+        -Dtools=disabled
+}
+
+
+subport gst-libav {
+    description \
+        GStreamer libav Plug-ins a plug-in using the libav library
+    long_description \
+        GStreamer libav plug-in contains  elements using the libav library code. It \
+        contains most popular decoders as well as very fast \
+        colorspace conversion elements.
+
+    worksrcdir \
+        ${worksrcpath}/subprojects/gst-libav
+
+    depends_build-append \
+        port:nasm
+    depends_lib-append \
+        port:gst-plugins-base \
+        port:ffmpeg
+
+    depends_lib-delete \
+        port:orc
+
+    configure.args-append \
+        -Ddoc=disabled
+
+    configure.args-delete \
+        -Dexamples=disabled \
+        -Dbenchmarks=disabled \
+        -Dtools=disabled \
+        -Dintrospection=disabled \
+        -Dnls=disabled \
+        -Dorc=enabled \
+        -Dgobject-cast-checks=disabled \
+        -Dglib-asserts=disabled \
+        -Dglib-checks=disabled \
+        -Dextra-checks=disabled
+}

--- a/multimedia/gstreamer/Portfile
+++ b/multimedia/gstreamer/Portfile
@@ -163,7 +163,6 @@ subport gst-plugins-good {
     depends_lib-append \
         port:flac \
         port:gst-plugins-base \
-        port:lame \
         path:lib/pkgconfig/vpx.pc:libvpx \
         port:mpg123
 
@@ -185,7 +184,7 @@ subport gst-plugins-good {
         -Dgtk3=disabled \
         -Djack=disabled \
         -Djpeg=disabled \
-        -Dlame=enabled \
+        -Dlame=disabled \
         -Dlibcaca=disabled \
         -Dmpg123=enabled \
         -Doss=disabled \

--- a/multimedia/gstreamer/Portfile
+++ b/multimedia/gstreamer/Portfile
@@ -164,8 +164,8 @@ subport gst-plugins-good {
         port:flac \
         port:gst-plugins-base \
         port:lame \
-        port:mpg123 \
-        port:libvpx
+        path:lib/pkgconfig/vpx.pc:libvpx \
+        port:mpg123
 
     # Feature options for plugins without external deps
     configure.args-append \


### PR DESCRIPTION
@gverm could you test these when you have chance these all built for me at least but need to do the wine tests (this isn’t gstreamer-monolithic that Portfile/pkg will come later)

@zfigura would you mind having a look over this and point out anything obvious you notice?

Plugins that don’t require an external library are simply left to auto unless it’s been disabled, some of those options were copied from GE-Proton as that’s the closest thing I can really reference for this but isn’t completely in sync with it.